### PR TITLE
Fix logger output issues.

### DIFF
--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -62,7 +62,8 @@ export function createLogger(config: LoggerConfig = {}): winston.Logger {
     // Console transport - always enabled
     new winston.transports.Console({
       format: consoleFormat,
-      level: level
+      level: level,
+      stderrLevels: ['error', 'warn', 'info', 'http', 'verbose', 'debug', 'silly']
     })
   ];
   


### PR DESCRIPTION
Was having issues with Cursor reporting an error when starting up the server. Specifically reconfigured src/utils/logger.ts to direct all log levels to stderr, resolving the JSON parsing errors. 

![mcp-enabled](https://github.com/user-attachments/assets/b16d5c32-f70b-4729-bc1c-54729974e2ea)
